### PR TITLE
Enable use with images stored on S3

### DIFF
--- a/src/Jobs/GenerateAltTextJob.php
+++ b/src/Jobs/GenerateAltTextJob.php
@@ -31,7 +31,7 @@ class GenerateAltTextJob implements ShouldQueue
         }
 
         // Create an image instance and resize it
-        $image = Image::make($asset->resolvedPath());
+        $image = Image::make($asset->contents());
 
         // Resize to max 1200px on longest side
         $width = $image->width();


### PR DESCRIPTION
$asset->contents() works on all assets, wherever they are stored (local or s3). $asset->resolvedPath() only works on locally stored files.