### PR TITLE
Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "require": {
         "php": "^8.1",
         "statamic/cms": "^4.0|^5.0",
-        "openai-php/client": "^v0.8.0",
-        "openai-php/laravel": "^v0.8.0"
+        "openai-php/client": "v0.12.0",
+        "openai-php/laravel": "v0.12.0"
     },
     "extra": {
         "statamic": {
@@ -24,5 +24,11 @@
             ]
         }
     },
-    "license": "MIT"
+    "license": "MIT",
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true,
+            "pixelfear/composer-dist-plugin": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,5 @@
             ]
         }
     },
-    "license": "MIT",
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true,
-            "pixelfear/composer-dist-plugin": true
-        }
-    }
+    "license": "MIT"
 }


### PR DESCRIPTION
Update openai-php library dependencies to support Laravel 12.

Dependency updates:

* Updated `openai-php/client` from `^v0.8.0` to `v0.12.0` to use the latest version of the package.
* Updated `openai-php/laravel` from `^v0.8.0` to `v0.12.0` to align with the updated client package.